### PR TITLE
`eb_is_text_stopped`: Fix crash when built with `--enable-pthread`

### DIFF
--- a/eb/readtext.c
+++ b/eb/readtext.c
@@ -1560,7 +1560,7 @@ eb_is_text_stopped(EB_Book *book)
 {
     int is_stopped = 0;
 
-    eb_lock(book);
+    eb_lock(&book->lock);
     LOG(("in: eb_is_text_stopped(book=%d)", (int)book->code));
 
     if (book->subbook_current != NULL) {


### PR DESCRIPTION
This fixes a crash when built with `--enable-pthread`. `eb_is_text_stopped()` calls `eb_lock()` on the `book` struct itself, instead of its `lock` member. Compiler warns too:

```
readtext.c: In function ‘eb_is_text_stopped’:
readtext.c:1563:13: warning: passing argument 1 of ‘eb_lock’ from incompatible pointer type [-Wincompatible-pointer-types]
 1563 |     eb_lock(book);
      |             ^~~~
      |             |
      |             EB_Book * {aka struct EB_Book_Struct *}
In file included from readtext.c:33:
build-post.h:277:23: note: expected ‘EB_Lock *’ {aka ‘struct EB_Lock_Struct *’} but argument is of type ‘EB_Book *’ {aka ‘struct EB_Book_Struct *’}
277 | void eb_lock(EB_Lock *lock);
    |              ~~~~~~~~~^~~~
```